### PR TITLE
Add status flow UI and backend messages

### DIFF
--- a/cesiumjs/main.html
+++ b/cesiumjs/main.html
@@ -27,17 +27,41 @@
       background: rgba(255, 255, 255, 0.1);
       position: absolute;
       top: 10px;
-      left: 10px;
+      right: 10px;
       z-index: 1000;
       border: 1px solid rgba(255, 255, 255, 0);
       font-family: Arial, sans-serif;
       color: white;
+    }
+
+    #statusBox {
+      position: absolute;
+      bottom: 10px;
+      left: 10px;
+      padding: 8px;
+      background: rgba(255, 255, 255, 0.1);
+      color: white;
+      font-family: Arial, sans-serif;
+      z-index: 1000;
+    }
+
+    #resultBox {
+      position: absolute;
+      bottom: 10px;
+      right: 10px;
+      padding: 8px;
+      background: rgba(255, 255, 255, 0.1);
+      color: white;
+      font-family: Arial, sans-serif;
+      z-index: 1000;
     }
   </style>
 </head>
 <body>
   <div id="cesiumContainer"></div>
   <div id="infoBox">等待連線...</div>
+  <div id="statusBox">狀態：等待連線</div>
+  <div id="resultBox">計算結果：-</div>
 
   <script>
     // ✅ 設定 Cesium Ion token
@@ -68,6 +92,8 @@
     viewer.scene.requestRender();
 
     const infoBox = document.getElementById('infoBox');
+    const statusBox = document.getElementById('statusBox');
+    const resultBox = document.getElementById('resultBox');
 
     let firstCapture = true;
     let captureWait = 1500;
@@ -95,12 +121,15 @@
 
             if (data.action === "get_cesium_picture") {
               console.log("收到觸發訊息: 執行 get_cesium_picture");
+              statusBox.textContent = "狀態：Cesium截圖";
+              infoBox.textContent = "沒有座標";
               captureAndUpload();
               return;
             }
 
             if (data.action === "send_Coordinates") {
               console.log("收到相機座標資料，更新攝影機畫面");
+              statusBox.textContent = "狀態：有座標";
               // 更新 InfoBox 顯示資訊
               infoBox.innerHTML = `
                 座標更新:<br>
@@ -215,6 +244,25 @@
               return;
             }
 
+            if (data.action === "status_update") {
+              const map = {
+                waiting_drone: "等待無人機回傳",
+                superglue: "SuperGlue",
+                calculation_done: "計算完成"
+              };
+              statusBox.textContent = `狀態：${map[data.step] || data.step}`;
+              return;
+            }
+
+            if (data.action === "calculation_result") {
+              resultBox.innerHTML = `
+                經度: ${data.longitude.toFixed(6)}<br>
+                緯度: ${data.latitude.toFixed(6)}<br>
+                高度: ${data.height.toFixed(2)}
+              `;
+              return;
+            }
+
           } catch (error) {
             console.error("資料解析錯誤:", error, event.data);
           }
@@ -271,6 +319,7 @@
         .then(response => response.json())
         .then(data => {
           console.log("上傳成功", data);
+          statusBox.textContent = "狀態：等待 SuperGlue";
 
           if (ws && ws.readyState === WebSocket.OPEN) {
             setTimeout(() => {

--- a/python/main.py
+++ b/python/main.py
@@ -115,6 +115,7 @@ async def handle_message(result: str, websocket):
 
         case "got_cesium_picture":
             print("收到 got_cesium_picture，開始匹配")
+            await websocket.send(json.dumps({"action": "status_update", "step": "superglue"}))
             run_superglue(matching, device)
             msg = json.dumps({"action": "request_coordinate"})
             await websocket.send(msg)
@@ -138,6 +139,13 @@ async def handle_message(result: str, websocket):
 
             lat, lon, height = run_solvepnp_from_json(str(match_path))
             print(f"相機 WGS84 位置：緯度={lat:.6f}, 經度={lon:.6f}, 高度={height:.2f}m")
+            await websocket.send(json.dumps({"action": "status_update", "step": "calculation_done"}))
+            await websocket.send(json.dumps({
+                "action": "calculation_result",
+                "latitude": lat,
+                "longitude": lon,
+                "height": height
+            }))
 
             # === 寫入 flight_information.json ===
             info_path = base / "data_base" / serial_number / "a" / "flight_information.json"


### PR DESCRIPTION
## Summary
- show separate status and result boxes in Cesium page
- broadcast calculation status from backend servers
- report SuperGlue and PnP result via WebSocket

## Testing
- `python -m py_compile python/main.py`
- `node --check node.js_server/main.js`


------
https://chatgpt.com/codex/tasks/task_e_687dfce254808333bfb029382f5fd821