### PR TITLE
保留解算失敗時的姿態資訊

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -148,12 +148,16 @@ async def handle_message(result: str, websocket):
                 prev_sn = config["serial_numbers"] - 1
                 prev_info_path = base / "data_base" / str(prev_sn) / "a" / "flight_information.json"
                 lat = lon = height = 0.0
+                heading = pitch = roll = None
                 if prev_info_path.exists():
                     with open(prev_info_path, "r", encoding="utf-8") as f:
                         prev_info = json.load(f)
                         lat = prev_info.get("latitude", 0.0)
                         lon = prev_info.get("longitude", 0.0)
                         height = prev_info.get("height", 0.0)
+                        heading = prev_info.get("heading")
+                        pitch = prev_info.get("pitch")
+                        roll = prev_info.get("roll")
 
                 await websocket.send(json.dumps({"action": "status_update", "step": "calculation_done"}))
                 await websocket.send(json.dumps({
@@ -161,6 +165,9 @@ async def handle_message(result: str, websocket):
                     "latitude": lat,
                     "longitude": lon,
                     "height": height,
+                    "heading": heading,
+                    "pitch": pitch,
+                    "roll": roll,
                     "status": "failed",
                     "note": "解算失敗"
                 }))
@@ -177,6 +184,9 @@ async def handle_message(result: str, websocket):
                     "latitude": lat,
                     "longitude": lon,
                     "height": height,
+                    "heading": heading,
+                    "pitch": pitch,
+                    "roll": roll,
                     "calculated": False,
                     "status": "failed",
                     "note": "解算失敗"


### PR DESCRIPTION
## Summary
- 在 solvePnP 失敗時同時讀取並保留上一筆的 heading、pitch、roll
- 將姿態資訊寫入 calculation_result 與 flight_information.json 以便前端維持視角

## Testing
- 未執行測試（非必要變更）

------
https://chatgpt.com/codex/tasks/task_e_68de2a62b2388333bec8ff2c23ba4274